### PR TITLE
jeeui: (wip) http stream fix for #3

### DIFF
--- a/lib/JeeUI2/JeeUI2.h
+++ b/lib/JeeUI2/JeeUI2.h
@@ -123,6 +123,7 @@ class jeeui2
 
     uiCallback foo;
     void ui(void (*uiFunction) ());
+    void uiPush();   // высвобождение буфера
 
     void mqtt(const String &pref, const String &host, int port, const String &user, const String &pass, void (*mqttFunction) (const String &topic, const String &payload), bool remotecontrol);
     void mqtt(const String &pref, const String &host, int port, const String &user, const String &pass, void (*mqttFunction) (const String &topic, const String &payload));
@@ -258,6 +259,7 @@ class jeeui2
     static char _t_pld_current[128]; // сообщение
     static bool _t_inc_current;
     static bool _t_remotecontrol;
+    AsyncResponseStream *httpstream=nullptr;  // указатель на http-поток
     String op; // опции для выпадающего списка <-- весьма желательно очищать сразу же...
 public:
     String buf; // борьба с фрагментацией кучи, буффер должен быть объявлен последним <-- весьма желательно очищать сразу же...

--- a/lib/JeeUI2/config.cpp
+++ b/lib/JeeUI2/config.cpp
@@ -90,3 +90,8 @@ void jeeui2::load(const char *_cfg)
         sv = false;
     }
 }
+
+void jeeui2::ui(void (*uiFunction) ())
+{
+    foo = uiFunction;
+}

--- a/lib/JeeUI2/gpio.cpp
+++ b/lib/JeeUI2/gpio.cpp
@@ -85,11 +85,6 @@ void jeeui2::led_inv(){
     digitalWrite(LED_PIN, !digitalRead(LED_PIN));
 }
 
-void jeeui2::ui(void (*uiFunction) ())
-{
-    foo = uiFunction;
-}
-
 void testFunction(){
 
 }

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -500,8 +500,8 @@ void interface(){ // функция в которой мф формируем в
 
         EFFECT enEff; enEff.setNone();
         jee.checkbox(F("ONflag"),F("Включение&nbspлампы"));
-        //char nameBuffer[64]; // Exception (3) при обращении к PROGMEM, поэтому ход конем - копируем во временный буффер
-        
+        jee.uiPush();       // не сбрасывать буфер перед page() после option(), это портит джейсон
+
         if(!iGLOBAL.isAddSetup){
             do {
                 enEff = *myLamp.effects.enumNextEffect(&enEff);
@@ -517,6 +517,8 @@ void interface(){ // функция в которой мф формируем в
             jee.select(F("effList"), F("Эффект"));
             jee.button(F("bSetClose"), F("gray"), F("Выйти из настроек"));
         }
+        jee.uiPush();
+
         jee.range(F("bright"),1,255,1,F("Яркость"));
         jee.range(F("speed"),1,255,1,F("Скорость"));
         jee.range(F("scale"),1,255,1,F("Масштаб"));
@@ -527,6 +529,7 @@ void interface(){ // функция в которой мф формируем в
         else
             jee.button(F("bDemo"),F("gray"),F("DEMO -> ON"));
         //jee.button(F("btn3"),F("gray"),F(">"), 3);
+        jee.uiPush();
 
         if(iGLOBAL.isSetup){
             jee.checkbox(F("canBeSelected"),F("В&nbspсписке&nbspвыбора"));
@@ -535,6 +538,8 @@ void interface(){ // функция в которой мф формируем в
         jee.checkbox(F("isSetup"),F("Конфигурирование"));
 
         jee.page(); // разделитель между страницами
+        jee.uiPush();
+
         //Страница "Управление лампой"
         if(iGLOBAL.isTmSetup){
             jee.time(F("time"),F("Время"));
@@ -552,6 +557,8 @@ void interface(){ // функция в которой мф формируем в
         jee.checkbox(F("isTmSetup"),F("Настройка&nbspвремени"));
 
         jee.page(); // разделитель между страницами
+        jee.uiPush();
+
         // Страница "Настройки соединения"
         // if(!jee.connected || jee.param(F("wifi"))==F("AP")){
         //     jee.formWifi(); // форма настроек Wi-Fi
@@ -572,6 +579,8 @@ void interface(){ // функция в которой мф формируем в
 #endif
             jee.option(F("9"), F("Другое"));
             jee.select(F("addSList"), F("Группа настроек"));
+            jee.uiPush();
+
             switch (iGLOBAL.addSList)
             {
             case 1:
@@ -703,6 +712,7 @@ void interface(){ // функция в которой мф формируем в
 #endif
         }
         jee.page(); // разделитель между страницами
+        jee.uiPush();
     } else {
 #ifdef LAMP_DEBUG
         LOG.println(F("Внимание: Загрузка минимального интерфейса, т.к. обнаружен вызов index.htm"));


### PR DESCRIPTION
по баге #3 c минимальными изменениями в jeeui получилось как-то так.
Не самое красивое решение, но другие варианты включают еще больше правок в различные методы jeeui. Основную проблему тут вносит, как ни странно, Async сервер. В силу своей природы ему нужен весь ответ целиком в любом случае. Будет он буферизован в клиентском коде или в буфере самого асинка - сути это не меняет. Единственное что тут можно сделать это, по возможности, избежать двойной буферизации полного тела, даже на короткое время (что и реализованно в этом патче).
Настоящий chunked transfer сделать еще сложнее, т.к. по сути это реализовать асинхронную функцию сборки интерфейса по кусочкам. Можно сделать, но это сломает совместимость как со стороны jeeui так и с текущим кодом interface().
@DmytroKorniienko, какие будут соображения? Сам jeeui отдельно вы не развиваете? Мне сложно сказать что тут вокруг чего строится - лампа вокруг jeeui или наоборот jeeui вокруг лампы :) 