### PR TITLE
FASTLED fix for esp32 build

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -40,7 +40,9 @@ JeeUI2 lib used under MIT License Copyright (c) 2019 Marsel Akhkamov
 
 #include <GyverButton.h>
 
+#ifdef ESP8266
 #define FASTLED_USE_PROGMEM             (1)
+#endif
 #define FASTLED_INTERRUPT_RETRY_COUNT   (0)                 // default: 2; // Use this to determine how many times FastLED will attempt to re-transmit a frame if interrupted for too long by interrupts
 #define FASTLED_ESP8266_RAW_PIN_ORDER                       // FASTLED_ESP8266_RAW_PIN_ORDER, FASTLED_ESP8266_D1_PIN_ORDER or FASTLED_ESP8266_NODEMCU_PIN_ORDER
 //#define FASTLED_ALLOW_INTERRUPTS      (0)                   // default: 1; // Use this to force FastLED to allow interrupts in the clockless chipsets (or to force it to disallow), overriding the default on platforms that support this. Set the value to 1 to allow interrupts or 0 to disallow them.


### PR DESCRIPTION
define FASTLED_USE_PROGMEM ломает сборку под esp32 из-за некорректного определения инклуда PGM в самой либе. Править надо в самой FastLED, но можно просто оставить прогмем только для 8266 :)