### PR TITLE
async brightness control, ported bdb42df

### DIFF
--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -769,7 +769,7 @@ void update(){ // функция выполняется после ввода д
             jee.var(F("ONflag"), (myLamp.isLampOn()?F("true"):F("false")));
 
             isRefresh = true;
-            myLamp.startFader(true);
+            myLamp.fadeeffect();
         } else {
             curEff->isFavorite = (jee.param(F("isFavorite"))==F("true"));
             curEff->canBeSelected = (jee.param(F("canBeSelected"))==F("true"));
@@ -878,7 +878,7 @@ void httpCallback(const char *param, const char *value)
                 jee.var(F("bright"), value);
             }
             myLamp.setLampBrightness(atoi(value));
-            FastLED.setBrightness(myLamp.getNormalizedLampBrightness());
+            myLamp.fadelight(myLamp.getNormalizedLampBrightness());
             //myLamp.setLoading(true); // перерисовать эффект
         }
     } else if(!strcmp_P(param,PSTR("speed"))){
@@ -901,11 +901,11 @@ void httpCallback(const char *param, const char *value)
     } else if(!strcmp_P(param,PSTR("move_next"))){
         myLamp.effects.moveNext();
         myLamp.setLoading(true); // перерисовать эффект
-        myLamp.startFader(true);
+        //myLamp.fadeeffect();       // код эффекта меняется сразу, а фейдер асинхроный, нужно чинить
     } else if(!strcmp_P(param,PSTR("move_prev"))){
         myLamp.effects.movePrev();
         myLamp.setLoading(true); // перерисовать эффект
-        myLamp.startFader(true);
+        //myLamp.fadeeffect();       // код эффекта меняется сразу, а фейдер асинхроный, нужно чинить
     }
     jee._refresh = true;
 }


### PR DESCRIPTION
Портировал свой патч, который делал под версию прошивки вилсера, там он особого интереса не вызвал. Пока сыроват для мерджа, но можно оценить и поделиться мнением интересен ли такой подход в дальнейшем?
Собссно основная мысль переходить на использование какого-нибудь планировщика и управлением событиями вместо дикого зоопарка глобальных переменных и millis()
В этом патче реализовал мягкий асинхронный фейдер, который работает в обе стороны (увеличение/уменьшение) при любом измеении яркости лампы и за которым не надо следить в циклах. В ввиду огромного числа мест где рулится яркость и эффекты где-то что-то наверняка упустил, но на первый взгляд смена эффектов в демо, и изменение яркости работает намного приятнее.

- Implemented async fader using scheduler, no more loop locking
- All global brigtness changes now uses fade effect via common cotrol
- Natural brighness control now uses dim function to compensate
for human's eye perception. Brighness 128 looks much closer
to human's 50% of maximum. Fader effect also look much better
