### PR TITLE
brt fix, interrupt driven key

### DIFF
--- a/include/lamp.h
+++ b/include/lamp.h
@@ -65,6 +65,12 @@ const char T_EVENT_DAYS[] PROGMEM = "ПНВТСРЧТПТСБВС";
 #define FADE_MININCREMENT    3      // Minimal increment for brightness fade
 #define FADE_MINCHANGEBRT   30      // Minimal brightness for effects changer
 
+#define BUTTON_DEBOUNCE     30      // Button debounce time, ms
+
+#define MIC_POLLRATE        50      // как часто опрашиваем микрофон, мс
+// Ticker constants
+
+
 struct EVENT {
     union {
         struct {
@@ -437,6 +443,7 @@ private:
     int8_t _brtincrement;
     Ticker _fadeTicker;             // планировщик асинхронного фейдера
     Ticker _fadeeffectTicker;       // планировщик затухалки между эффектами
+    Ticker _buttonTicker;           // планировщик кнопки
     void brightness(const uint8_t _brt, bool natural=true);     // низкоуровневая крутилка глобальной яркостью для других методов
     void fader(const uint8_t _tgtbrt);          // обработчик затуания, вызывается планировщиком
 
@@ -467,6 +474,7 @@ private:
     uint8_t getFont(uint8_t asciiCode, uint8_t row);
 
     void alarmWorker();
+    void buttonPress(bool state);                 // обертка для обработчика прерываний
 
 public:
     EffectWorker effects; // объект реализующий доступ к эффектам
@@ -598,6 +606,10 @@ public:
      */
     void fadelight(const uint8_t _targetbrightness=0, const uint32_t _duration=FADE_TIME);
 
+    /*
+     *   хук обработчика прерываний для кнопки
+     */ 
+    ICACHE_RAM_ATTR void buttonisr(bool state){ _buttonTicker.once_ms_scheduled(0, std::bind(&LAMP::buttonPress, this, state)); } // "нажатие", запускаем обертку
 
     ~LAMP() {}
 private:

--- a/include/main.h
+++ b/include/main.h
@@ -41,13 +41,22 @@ JeeUI2 lib used under MIT License Copyright (c) 2019 Marsel Akhkamov
 #include "config.h"
 #include "lamp.h"
 
+#if (PULL_MODE == LOW_PULL)
+#define BUTTON_PRESS_TRANSITION RISING
+#define BUTTON_RELEASE_TRANSITION FALLING
+#else
+#define BUTTON_PRESS_TRANSITION FALLING
+#define BUTTON_RELEASE_TRANSITION RISING
+#endif
+
+
 // глобальные переменные для работы с ними в программе
 extern SHARED_MEM GSHMEM; // Глобальная разделяемая память эффектов
 extern int mqtt_int; // интервал отправки данных по MQTT в секундах 
 extern jeeui2 jee; // Создаем объект класса для работы с JeeUI2 фреймворком
 extern LAMP myLamp; // Объект лампы
 #ifdef ESP_USE_BUTTON
-extern GButton touch;               
+extern GButton touch;
 #endif
 
 void mqttCallback(const String &topic, const String &payload);
@@ -59,3 +68,4 @@ void updateParm();
 void jeebuttonshandle();
 void event_worker(const EVENT *);
 void httpCallback(const char *param, const char *value);
+ICACHE_RAM_ATTR void buttonpinisr();    // обработчик прерываний пина кнопки

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,7 +50,7 @@ SHARED_MEM GSHMEM; // глобальная общая память эффект�
 int mqtt_int; // интервал отправки данных по MQTT в секундах 
 jeeui2 jee; // Создаем объект класса для работы с JeeUI2 фреймворком
 LAMP myLamp;
-
+bool pinTransition = 1;  // ловим "нажатие" кнопки
 
 void setup() {
     Serial.begin(115200);
@@ -91,6 +91,9 @@ void setup() {
     myLamp.events.setEventCallback(event_worker);
 
     jee.mqtt(jee.param(F("m_host")), jee.param(F("m_port")).toInt(), jee.param(F("m_user")), jee.param(F("m_pass")), mqttCallback, true); // false - никакой автоподписки!!!
+#ifdef ESP_USE_BUTTON
+    attachInterrupt(digitalPinToInterrupt(BTN_PIN), buttonpinisr, BUTTON_PRESS_TRANSITION);  // цепляем прерывание на кнопку
+#endif
 }
 
 void loop() {
@@ -129,4 +132,14 @@ void sendData(){
   LOG.printf_P(PSTR("MQTT send data, MEM: %d, Time: %s\n"), ESP.getFreeHeap(), myLamp.timeProcessor.getFormattedShortTime().c_str());
 #endif
   //jee.publish(F("jee/set/BTN_bRefresh"),F("*"));
+}
+
+/*
+ *  Button pin interrupt handler
+ */
+ICACHE_RAM_ATTR void buttonpinisr(){
+  detachInterrupt(BTN_PIN);
+  myLamp.buttonisr(pinTransition);   // дергаем хук в лампе
+  pinTransition = !pinTransition;
+  attachInterrupt(digitalPinToInterrupt(BTN_PIN), buttonpinisr, pinTransition ? BUTTON_PRESS_TRANSITION : BUTTON_RELEASE_TRANSITION);  // меням прерывание
 }


### PR DESCRIPTION
исправления работы фейдера и контроля яркости для кнопки и граничных состояний

кнопка переведена на использование прерываний по пину вместо циклического опроса по таймауту
